### PR TITLE
Reduced auth0 applications per cluster to one

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,30 +7,16 @@
 # the AWS providr credentials are handled.
 #
 
-resource "auth0_client" "kubernetes" {
-  name        = "${var.cluster_name}:kubernetes"
-  description = "Cloud Platform kubernetes"
-  app_type    = "regular_web"
-
-  callbacks = [format("https://login.%s/ui", var.services_base_domain)]
-
-  custom_login_page_on = true
-  is_first_party       = true
-  oidc_conformant      = true
-  sso                  = true
-
-  jwt_configuration {
-    alg                 = "RS256"
-    lifetime_in_seconds = "2592000"
-  }
-}
-
 resource "auth0_client" "components" {
   name        = "${var.cluster_name}:components"
   description = "Cloud Platform components"
   app_type    = "regular_web"
 
   callbacks = [
+    format(
+      "https://login.%s/ui",
+      var.services_base_domain,
+    ),
     format(
       "https://prometheus.%s/oauth2/callback",
       var.services_base_domain,

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,10 +1,3 @@
-output "oidc_kubernetes_client_id" {
-  value = auth0_client.kubernetes.client_id
-}
-
-output "oidc_kubernetes_client_secret" {
-  value = auth0_client.kubernetes.client_secret
-}
 
 output "oidc_components_client_id" {
   value = auth0_client.components.client_id


### PR DESCRIPTION
This reduces the number of auth0 applications created **per cluster** to 1. Before we were creating two applications per cluster, for instance: _live1:kubernetes_ and _live1:components_ or _manager:kubernetes_ and _manager:components_. With this change, we are just creating one **$clusterName:components**.