### PR TITLE
Update auth0 to add kubernetes auth0_client

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -63,6 +63,10 @@ resource "auth0_client" "components" {
       "https://kube-ops.%s/login/authorized",
       var.services_base_domain,
     ),
+    format(
+      "https://sonarqube.%s/oauth2/callback/oidc",
+      var.services_base_domain,
+    ),
   ]
 
   custom_login_page_on = true

--- a/main.tf
+++ b/main.tf
@@ -36,10 +36,6 @@ resource "auth0_client" "components" {
 
   callbacks = [
     format(
-      "https://login.%s/ui",
-      var.services_base_domain,
-    ),
-    format(
       "https://prometheus.%s/oauth2/callback",
       var.services_base_domain,
     ),

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,28 @@
 # the AWS providr credentials are handled.
 #
 
+resource "auth0_client" "kubernetes" {
+  name        = "${var.cluster_name}:kubernetes"
+  description = "Cloud Platform kubernetes"
+  app_type    = "regular_web"
+
+  callbacks = [
+    format(
+      "https://login.%s/ui",
+    var.services_base_domain)
+  ]
+
+  custom_login_page_on = true
+  is_first_party       = true
+  oidc_conformant      = true
+  sso                  = true
+
+  jwt_configuration {
+    alg                 = "RS256"
+    lifetime_in_seconds = "2592000"
+  }
+}
+
 resource "auth0_client" "components" {
   name        = "${var.cluster_name}:components"
   description = "Cloud Platform components"
@@ -57,4 +79,3 @@ resource "auth0_client" "components" {
     lifetime_in_seconds = "36000"
   }
 }
-

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,3 +6,11 @@ output "oidc_components_client_id" {
 output "oidc_components_client_secret" {
   value = auth0_client.components.client_secret
 }
+
+output "oidc_kubernetes_client_id" {
+  value = auth0_client.kubernetes.client_id
+}
+
+output "oidc_kubernetes_client_secret" {
+  value = auth0_client.kubernetes.client_secret
+}


### PR DESCRIPTION
This change is to revert multiple tenant single application to single tenant and multiple application(kubernetes & components)

- Add kubernetes auth0_client with kuberos login callback
- Remove kuberos login call back from components
- Add sonarqube call back url