### PR TITLE
Refactor the auth0 module to be more flexible

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,19 @@
+name: Generate terraform docs
+on:
+  - pull_request
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.ref }}
+
+    - name: Render terraform docs and push changes back to PR
+      uses: terraform-docs/gh-actions@v0.6.0
+      with:
+        working-dir: .
+        output-file: README.md
+        output-method: inject
+        git-push: "true"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,44 @@ module "auth0" {
 ```
 
 <!--- BEGIN_TF_DOCS --->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.13 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| auth0 | n/a |
+
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [auth0_client](https://registry.terraform.io/providers/alexkappa/auth0/latest/docs/resources/client) |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| cluster\_name | Kubernetes cluster name - used to name (id) the auth0 resources | `any` | n/a | yes |
+| extra\_callbacks | Extra callbacks URLs that can be added to the auth0 application - e.g: concourse, sonarqube, etc | `list(any)` | `null` | no |
+| services\_base\_domain | Base domain to be used for the callbacks URLs | `any` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| oidc\_components\_client\_id | Components OIDC Client ID |
+| oidc\_components\_client\_secret | Components OIDC Client Secret |
+| oidc\_kubernetes\_client\_id | Kubernetes OIDC Client ID |
+| oidc\_kubernetes\_client\_secret | Kubernetes OIDC Client Secret |
 
 <!--- END_TF_DOCS --->
 

--- a/README.md
+++ b/README.md
@@ -14,19 +14,7 @@ module "auth0" {
 }
 ```
 
-## Inputs
+<!--- BEGIN_TF_DOCS --->
 
-|         Name          |                     Description               | Type   | Default | Required |
-|-----------------------|-----------------------------------------------|:------:|:-------:|:--------:|
-| cluster_name          | The VPC where bastion is going to be deployed | string |         | yes      |
-| services_base_domain  | The DNS hostzone used within the auth0's Applications for the callbacks URLs| string | | yes |
-| services_eks_domain   | The DNS hostzone used within the auth0's Applications for EKS callbacks URLs| string | | yes |
+<!--- END_TF_DOCS --->
 
-## Outputs
-
-|           Name                |          Description          |
-|-------------------------------|-------------------------------|
-| oidc_kubernetes_client_id     | Kubernetes OIDC Client ID     |
-| oidc_kubernetes_client_secret | Kubernetes OIDC Client Secret |
-| oidc_components_client_id     | Components OIDC Client ID     |
-| oidc_components_client_secret | Components OIDC Client Secret |

--- a/main.tf
+++ b/main.tf
@@ -34,21 +34,7 @@ resource "auth0_client" "components" {
   description = "Cloud Platform components"
   app_type    = "regular_web"
 
-  callbacks =   var.eks == true ? concat(local.callbacks_default , local.callbacks_eks) : local.callbacks_default
-
-  custom_login_page_on = true
-  is_first_party       = true
-  oidc_conformant      = true
-  sso                  = true
-
-  jwt_configuration {
-    alg                 = "RS256"
-    lifetime_in_seconds = "36000"
-  }
-}
-
-locals {
-  callbacks_default    = [
+  callbacks = concat([
     format(
       "https://prometheus.%s/oauth2/callback",
       var.services_base_domain,
@@ -81,15 +67,15 @@ locals {
       "https://kube-ops.%s/login/authorized",
       var.services_base_domain,
     ),
-  ]
-  callbacks_eks    = [
-    format(
-      "https://sonarqube.%s/oauth2/callback/oidc",
-      var.services_eks_domain,
-    ),
-    format(
-      "https://concourse.%s/sky/issuer/callback",
-      var.services_base_domain,
-    ),
-  ]
+  ], var.extra_callbacks)
+
+  custom_login_page_on = true
+  is_first_party       = true
+  oidc_conformant      = true
+  sso                  = true
+
+  jwt_configuration {
+    alg                 = "RS256"
+    lifetime_in_seconds = "36000"
+  }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,16 +1,19 @@
-
 output "oidc_components_client_id" {
-  value = auth0_client.components.client_id
+  value       = auth0_client.components.client_id
+  description = "Components OIDC Client ID"
 }
 
 output "oidc_components_client_secret" {
-  value = auth0_client.components.client_secret
+  value       = auth0_client.components.client_secret
+  description = "Components OIDC Client Secret"
 }
 
 output "oidc_kubernetes_client_id" {
-  value = auth0_client.kubernetes.client_id
+  value       = auth0_client.kubernetes.client_id
+  description = "Kubernetes OIDC Client ID"
 }
 
 output "oidc_kubernetes_client_secret" {
-  value = auth0_client.kubernetes.client_secret
+  value       = auth0_client.kubernetes.client_secret
+  description = "Kubernetes OIDC Client Secret"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,17 +1,13 @@
 variable "cluster_name" {
-  description = "Kubernetes cluster name"
+  description = "Kubernetes cluster name - used to name (id) the auth0 resources"
 }
 
 variable "services_base_domain" {
-  description = "Base domain to be used"
+  description = "Base domain to be used for the callbacks URLs"
 }
 
-variable "services_eks_domain" {
-  description = "Base domain to be used for EKS cluster"
-}
-
-variable "eks" {
-  description = "kops cluster or EKS"
-  type        = bool
-  default     = false
+variable "extra_callbacks" {
+  description = "Extra callbacks URLs that can be added to the auth0 application - e.g: concourse, sonarqube, etc"
+  default     = null
+  type        = list(any)
 }


### PR DESCRIPTION
Because of the work in EKS, this auth0 refactor improves:
- Having fewer variables, things were hardcoded for the manager cluster (concourse, sonarqe, etc)
- Not the extra-callbacks are variables, not defined within this module but passed from the definition.
- Added terraform docs
