### PR TITLE
Set default to [""]

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ No Modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | cluster\_name | Kubernetes cluster name - used to name (id) the auth0 resources | `any` | n/a | yes |
-| extra\_callbacks | Extra callbacks URLs that can be added to the auth0 application - e.g: concourse, sonarqube, etc | `list(any)` | `null` | no |
+| extra\_callbacks | Extra callbacks URLs that can be added to the auth0 application - e.g: concourse, sonarqube, etc | `list(any)` | <pre>[<br>  ""<br>]</pre> | no |
 | services\_base\_domain | Base domain to be used for the callbacks URLs | `any` | n/a | yes |
 
 ## Outputs

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,6 @@ variable "services_base_domain" {
 
 variable "extra_callbacks" {
   description = "Extra callbacks URLs that can be added to the auth0 application - e.g: concourse, sonarqube, etc"
-  default     = null
+  default     = [""]
   type        = list(any)
 }


### PR DESCRIPTION
When creating test clusters, this variable is using the default null and throw error `Invalid value for "seqs" parameter: argument must not be null.`

This variable  cannot accept null by default as the type is list(any). 

