### PR TITLE
Update alexkappa/auth0 to auth0/auth0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     auth0 = {
-      source = "alexkappa/auth0"
+      source  = "auth0/auth0"
+      version = ">=0.27.0"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
[alexkappa/auth0](https://github.com/alexkappa/terraform-provider-auth0) has moved to [auth0/auth0](https://github.com/auth0/terraform-provider-auth0) as of version 0.27.0, so this PR updates the reference in this configuration.